### PR TITLE
Python 3 compatibility

### DIFF
--- a/kloudless/config.py
+++ b/kloudless/config.py
@@ -1,5 +1,7 @@
 from . import throttling
 
+import six
+
 _configuration = {
     'api_key': None,
     'dev_key': None,
@@ -26,7 +28,7 @@ def configure(**params):
 
 def merge(config):
     result = _configuration.copy()
-    for k, v in config.iteritems():
+    for k, v in six.iteritems(config):
         if k in result:
             result[k] = v
     return result

--- a/kloudless/http.py
+++ b/kloudless/http.py
@@ -37,7 +37,7 @@ _get_requestor = functools.partial
 def request(method, path, configuration=None, **kwargs):
     if configuration is None: configuration = {}
     configuration = config.merge(configuration)
-    
+
     if path.startswith('applications'):
         if not configuration['dev_key']:
             raise exceptions.ConfigurationException(
@@ -47,7 +47,7 @@ def request(method, path, configuration=None, **kwargs):
                 "requests.")
 
         kwargs['auth'] = DevKeyAuth(configuration['dev_key'])
-    
+
     elif configuration['api_key']:
         kwargs['auth'] = APIKeyAuth(configuration['api_key'])
     elif configuration['token']:

--- a/kloudless/resources.py
+++ b/kloudless/resources.py
@@ -6,6 +6,7 @@ from . import config
 import inspect
 import json
 import requests
+import six
 import warnings
 
 
@@ -68,7 +69,7 @@ class BaseResource(dict):
             if k in self._serializers:
                 data[k] = self._serializers[k][1](v)
 
-        for k, v in data.iteritems():
+        for k, v in six.iteritems(data):
             super(BaseResource, self).__setitem__(
                 k, self.__class__.create_from_data(
                     v, parent_resource=self._parent_resource,
@@ -110,7 +111,7 @@ class BaseResource(dict):
             to populate the resource.
         """
         serialized = {}
-        for k, v in resource_data.iteritems():
+        for k, v in six.iteritems(resource_data):
             if isinstance(v, BaseResource):
                 serialized[k] = v.serialize(v)
             elif k in cls._serializers:
@@ -142,7 +143,7 @@ class BaseResource(dict):
             raise AttributeError(k)
         try:
             return self[k]
-        except KeyError, e:
+        except KeyError as e:
             raise AttributeError(*e.args)
 
     def __setitem__(self, k, v):
@@ -180,7 +181,7 @@ class AnnotatedList(list):
             return all_data
 
         objects = None
-        for k, v in all_data.iteritems():
+        for k, v in six.iteritems(all_data):
             if k in ['objects', 'permissions'] and isinstance(v, list):
                 objects = v
             else:
@@ -270,7 +271,7 @@ class UpdateMixin(object):
         data = self.serialize(self)
 
         new_data = {}
-        for k, v in data.iteritems():
+        for k, v in six.iteritems(data):
             if k not in self._previous_data or self._previous_data[k] != v:
                 # Attribute is new or was updated
                 new_data[k] = v
@@ -398,7 +399,7 @@ class Account(BaseResource, ReadMixin, WriteMixin, Proxy):
                               'token_secret', 'refresh_token', 'token_expiry',
                               'refresh_token_expiry']
         serialized = {}
-        for k, v in resource_data.iteritems():
+        for k, v in six.iteritems(resource_data):
             if isinstance(v, BaseResource):
                 serialized[k] = v.serialize_account(v)
             elif k not in account_properties:
@@ -985,4 +986,4 @@ resources = {
     'apikey': ApiKey,
     'webhook': WebHook,
 }
-resource_types = {v: k for k, v in resources.iteritems()}
+resource_types = {v: k for k, v in six.iteritems(resources)}

--- a/kloudless/util.py
+++ b/kloudless/util.py
@@ -3,6 +3,8 @@ import logging
 import dateutil.parser
 from datetime import datetime
 
+import six
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
@@ -19,7 +21,7 @@ def to_iso(obj):
     """
     Converts datetime object to an ISO 8601 timestamp.
     """
-    if isinstance(obj, str) or obj is None:
+    if isinstance(obj, six.string_types) or obj is None:
         return obj
     elif isinstance(obj, datetime):
         timestamp = obj.isoformat()

--- a/kloudless/util.py
+++ b/kloudless/util.py
@@ -12,17 +12,14 @@ def to_datetime(timestamp):
     """
     if isinstance(timestamp, datetime) or timestamp is None:
         return timestamp
-    elif isinstance(timestamp, basestring):
-        return dateutil.parser.parse(timestamp)
-    else:
-        raise Exception("Unable to convert %s to a datetime object." %
-                        timestamp)
+
+    return dateutil.parser.parse(timestamp)
 
 def to_iso(obj):
     """
     Converts datetime object to an ISO 8601 timestamp.
     """
-    if isinstance(obj, basestring) or obj is None:
+    if isinstance(obj, str) or obj is None:
         return obj
     elif isinstance(obj, datetime):
         timestamp = obj.isoformat()

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,11 +1,7 @@
 import sys
 import imp
 
-# To handle package name changes
-setup = imp.load_source('setup', '../../setup.py')
-sys.modules['sdk'] = __import__(setup.package_name)
-
-import sdk
+import kloudless
 
 from functools import wraps
 
@@ -18,10 +14,10 @@ def configured_test(f):
     """
     @wraps(f)
     def wrapper(*args, **kwargs):
-        default_config = sdk.config.configure()
-        sdk.configure(**test_configuration)
+        default_config = kloudless.config.configure()
+        kloudless.configure(**test_configuration)
         result = f(*args, **kwargs)
-        sdk.configure(**default_config)
+        kloudless.configure(**default_config)
         return result
     return wrapper
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,6 +2,8 @@ import helpers
 
 import kloudless
 
+import six
+
 def test_configure():
     """
     This is a basic test to make sure that the configuration mechanism works.
@@ -11,6 +13,6 @@ def test_configure():
                "api_version": 31337,
                "base_url": "example.com"}
     kloudless.configure(**configs)
-    for key in configs.iterkeys():
+    for key in six.iterkeys(configs):
         assert configs[key] == kloudless.config._configuration[key]
     kloudless.configure(**default_configs)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,16 +1,16 @@
 import helpers
 
-import sdk
+import kloudless
 
 def test_configure():
     """
     This is a basic test to make sure that the configuration mechanism works.
     """
-    default_configs = sdk.config.configure()
+    default_configs = kloudless.config.configure()
     configs = {"api_key": "TESTKEY",
                "api_version": 31337,
                "base_url": "example.com"}
-    sdk.configure(**configs)
+    kloudless.configure(**configs)
     for key in configs.iterkeys():
-        assert configs[key] == sdk.config._configuration[key]
-    sdk.configure(**default_configs)
+        assert configs[key] == kloudless.config._configuration[key]
+    kloudless.configure(**default_configs)

--- a/tests/unit/test_http.py
+++ b/tests/unit/test_http.py
@@ -1,7 +1,7 @@
 import requests
 
 import helpers
-from sdk import http, exceptions
+from kloudless import http, exceptions
 
 def test_unconfigured_request():
     try:

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -46,7 +46,7 @@ def test_folder_contents():
         assert len(contents) > 0
         assert all([(isinstance(x, Folder) or isinstance(x, File)) for x in contents])
         mock_req.assert_called_with(folder._api_session.get,
-                                    ('accounts/%s/folders/root/contents'
+                                    ('accounts/%s/storage/folders/root/contents'
                                         % account.id),
                                     configuration=account._configuration)
 
@@ -64,7 +64,7 @@ def test_folder_metadata():
         for attr in ['id', 'name', 'type', 'size', 'account']:
             assert folder_data[attr] == getattr(folder, attr)
         mock_req.assert_called_with(Folder._api_session.get,
-                                    ('accounts/%s/folders/%s'
+                                    ('accounts/%s/storage/folders/%s'
                                         % (account.id, folder_data['id'])),
                                     configuration=None,
                                     params={})
@@ -85,7 +85,7 @@ def test_folder_creation():
         for attr in ['id', 'name', 'type', 'size', 'account']:
             assert folder_data[attr] == getattr(folder, attr)
         mock_req.assert_called_with(Folder._api_session.post,
-                                    'accounts/%s/folders' % account.id,
+                                    'accounts/%s/storage/folders' % account.id,
                                     configuration=None, params={},
                                     data={'name': 'TestFolder',
                                           'parent_id': 'root'})
@@ -102,7 +102,7 @@ def test_folder_delete():
                                          parent_resource=account)
         folder.delete()
         mock_req.assert_called_with(Folder._api_session.delete,
-                                    ('accounts/%s/folders/%s'
+                                    ('accounts/%s/storage/folders/%s'
                                      % (account.id, folder_data['id'])),
                                     configuration=account._configuration,
                                     params={})
@@ -121,7 +121,7 @@ def test_file_metadata():
         for attr in ['id', 'name', 'type', 'size', 'account']:
             assert file_data[attr] == getattr(file_obj, attr)
         mock_req.assert_called_with(File._api_session.get,
-                                    ('accounts/%s/files/%s'
+                                    ('accounts/%s/storage/files/%s'
                                         % (account.id, file_data['id'])),
                                     configuration=None,
                                     params={})
@@ -138,7 +138,7 @@ def test_file_contents():
         file_contents = file_obj.contents()
         assert isinstance(file_contents, Response)
         mock_req.assert_called_with(file_obj._api_session.get,
-                                    ('accounts/%s/files/%s/contents'
+                                    ('accounts/%s/storage/files/%s/contents'
                                         % (account.id, file_data['id'])),
                                     configuration=file_obj._configuration,
                                     stream=True)
@@ -154,7 +154,7 @@ def test_file_delete():
         mock_req.return_value = resp
         file_obj.delete()
         mock_req.assert_called_with(file_obj._api_session.delete,
-                                    ('accounts/%s/files/%s'
+                                    ('accounts/%s/storage/files/%s'
                                         % (account.id, file_data['id'])),
                                     configuration=file_obj._configuration,
                                     params={})
@@ -175,7 +175,7 @@ def test_file_upload():
         for attr in ['id', 'name', 'type', 'size', 'account']:
             assert file_data[attr] == getattr(file_obj, attr)
         mock_req.assert_called_with(File._api_session.post,
-                                    'accounts/%s/files' % account.id,
+                                    'accounts/%s/storage/files' % account.id,
                                     data={'metadata':json.dumps({
                                                 'name': file_data['name'],
                                                 'parent_id': 'root'})},
@@ -202,7 +202,7 @@ def test_file_update():
         expected_calls = [
                           # This is updating the file
                           call(file_obj._api_session.patch,
-                               'accounts/%s/files/%s' % (account.id,
+                               'accounts/%s/storage/files/%s' % (account.id,
                                                          file_data['id']),
                                params={},
                                data={'name': u'NewFileName',
@@ -232,7 +232,7 @@ def test_file_copy():
         expected_calls = [
                           # This is copying the file
                           call(file_obj._api_session.post,
-                               'accounts/%s/files/%s/copy' % (account.id,
+                               'accounts/%s/storage/files/%s/copy' % (account.id,
                                                          file_data['id']),
                                data={'name': u'NewFileName',
                                      'parent_id': 'root'},

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -176,11 +176,15 @@ def test_file_upload():
             assert file_data[attr] == getattr(file_obj, attr)
         mock_req.assert_called_with(File._api_session.post,
                                     'accounts/%s/storage/files' % account.id,
-                                    data={'metadata':json.dumps({
+                                    data=helpers.file_contents,
+                                    headers={
+                                        'Content-Type':
+                                            'application/octet-stream',
+                                        'X-Kloudless-Metadata': json.dumps({
                                                 'name': file_data['name'],
-                                                'parent_id': 'root'})},
-                                    files={'file': helpers.file_contents},
-                                    params={},
+                                                'parent_id': 'root'})
+                                    },
+                                    params=None,
                                     configuration=None)
 
 @helpers.configured_test

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -5,14 +5,14 @@ from mock import MagicMock, patch, call
 from requests.models import Response
 
 import helpers
-import sdk
-from sdk.resources import Account, Folder, File
+import kloudless
+from kloudless.resources import Account, Folder, File
 
 @helpers.configured_test
 def test_account_list():
     resp = Response()
     resp._content = helpers.account_list
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         mock_req.return_value = resp
         accounts = Account().all()
         assert len(accounts) > 0
@@ -20,7 +20,7 @@ def test_account_list():
 
 @helpers.configured_test
 def test_account_retrieve():
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.account
         mock_req.return_value = resp
@@ -37,7 +37,7 @@ def test_account_retrieve():
 @helpers.configured_test
 def test_folder_contents():
     account = Account.create_from_data(json.loads(helpers.account))
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.root_folder_contents
         mock_req.return_value = resp
@@ -53,7 +53,7 @@ def test_folder_contents():
 @helpers.configured_test
 def test_folder_metadata():
     account = Account.create_from_data(json.loads(helpers.account))
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.folder_data
         mock_req.return_value = resp
@@ -73,7 +73,7 @@ def test_folder_metadata():
 def test_folder_creation():
     account = Account.create_from_data(json.loads(helpers.account))
     folder_data = json.loads(helpers.folder_data)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp.status_code = 201
         resp._content = helpers.folder_data
@@ -94,7 +94,7 @@ def test_folder_creation():
 def test_folder_delete():
     account = Account.create_from_data(json.loads(helpers.account))
     folder_data = json.loads(helpers.folder_data)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp.status_code = 204
         mock_req.resturn_value = resp
@@ -111,7 +111,7 @@ def test_folder_delete():
 def test_file_metadata():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.file_data
         mock_req.return_value = resp
@@ -131,7 +131,7 @@ def test_file_contents():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
     file_obj = File.create_from_data(file_data, parent_resource=account)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.file_contents
         mock_req.return_value = resp
@@ -148,7 +148,7 @@ def test_file_delete():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
     file_obj = File.create_from_data(file_data, parent_resource=account)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp.status_code = 204
         mock_req.return_value = resp
@@ -163,7 +163,7 @@ def test_file_delete():
 def test_file_upload():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp._content = helpers.file_data
         mock_req.return_value = resp
@@ -188,7 +188,7 @@ def test_file_update():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
     file_obj = File.create_from_data(file_data, parent_resource=account)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         new_data = file_data.copy()
         new_data['name'] = 'NewFileName'
@@ -220,7 +220,7 @@ def test_file_copy():
     account = Account.create_from_data(json.loads(helpers.account))
     file_data = json.loads(helpers.file_data)
     file_obj = File.create_from_data(file_data, parent_resource=account)
-    with patch('sdk.resources.request') as mock_req:
+    with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         new_data = file_data.copy()
         new_data['name'] = 'NewFileName'

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -11,7 +11,8 @@ from kloudless.resources import Account, Folder, File
 @helpers.configured_test
 def test_account_list():
     resp = Response()
-    resp._content = helpers.account_list
+    resp._content = helpers.account_list.encode('utf-8')
+    resp.encoding = 'utf-8'
     with patch('kloudless.resources.request') as mock_req:
         mock_req.return_value = resp
         accounts = Account().all()
@@ -22,7 +23,8 @@ def test_account_list():
 def test_account_retrieve():
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
-        resp._content = helpers.account
+        resp._content = helpers.account.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         account_data = json.loads(helpers.account)
         account = Account().retrieve(account_data['id'])
@@ -39,7 +41,8 @@ def test_folder_contents():
     account = Account.create_from_data(json.loads(helpers.account))
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
-        resp._content = helpers.root_folder_contents
+        resp._content = helpers.root_folder_contents.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         folder = account.folders()
         contents = folder.contents()
@@ -55,7 +58,8 @@ def test_folder_metadata():
     account = Account.create_from_data(json.loads(helpers.account))
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
-        resp._content = helpers.folder_data
+        resp._content = helpers.folder_data.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         folder_data = json.loads(helpers.folder_data)
         folder = Folder.retrieve(id=folder_data['id'],
@@ -76,7 +80,8 @@ def test_folder_creation():
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
         resp.status_code = 201
-        resp._content = helpers.folder_data
+        resp._content = helpers.folder_data.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         folder = Folder.create(parent_resource=account,
                                data={'name': "TestFolder",
@@ -113,7 +118,8 @@ def test_file_metadata():
     file_data = json.loads(helpers.file_data)
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
-        resp._content = helpers.file_data
+        resp._content = helpers.file_data.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         file_obj = File.retrieve(id=file_data['id'],
                                  parent_resource=account)
@@ -165,7 +171,8 @@ def test_file_upload():
     file_data = json.loads(helpers.file_data)
     with patch('kloudless.resources.request') as mock_req:
         resp = Response()
-        resp._content = helpers.file_data
+        resp._content = helpers.file_data.encode('utf-8')
+        resp.encoding = 'utf-8'
         mock_req.return_value = resp
         file_obj = File.create(parent_resource=account,
                                file_name=file_data['name'],
@@ -196,9 +203,11 @@ def test_file_update():
         resp = Response()
         new_data = file_data.copy()
         new_data['name'] = 'NewFileName'
-        resp._content = json.dumps(new_data)
+        resp._content = json.dumps(new_data).encode('utf-8')
+        resp.encoding = 'utf-8'
         account_resp = Response()
-        account_resp._content = helpers.account
+        account_resp._content = helpers.account.encode('utf-8')
+        account_resp.encoding = 'utf-8'
         mock_req.side_effect = (resp,account_resp)
         file_obj.name = 'NewFileName'
         file_obj.parent_id = 'root'
@@ -228,7 +237,8 @@ def test_file_copy():
         resp = Response()
         new_data = file_data.copy()
         new_data['name'] = 'NewFileName'
-        resp._content = json.dumps(new_data)
+        resp._content = json.dumps(new_data).encode('utf-8')
+        resp.encoding = 'utf-8'
         account_resp = Response()
         account_resp._content = helpers.account
         mock_req.side_effect = (resp,account_resp)

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ deps=
     pytest-cov
 commands=
     pip install -e .
-    py.test {posargs} --basetemp={envtmpdir} tests/unit
+    py.test {posargs} --basetemp={envtmpdir} -s tests/unit

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27
+envlist = py{27,35}
 
 [testenv]
-changedir=tests/unit
 deps=
     mock
     pytest
     pytest-cov
-commands=py.test {posargs} --basetemp={envtmpdir}
-    
+commands=
+    pip install -e .
+    py.test {posargs} --basetemp={envtmpdir} tests/unit


### PR DESCRIPTION
Adds support for Python 3.

In the future, requests should be mocked using a library like "responses" or similar.

It may be good to run integration tests in Travis CI with environment variables to use someone's private Kloudless account.