### PR TITLE
Create 'user_headers' parameter for all API functions

### DIFF
--- a/kloudless/resources.py
+++ b/kloudless/resources.py
@@ -200,10 +200,12 @@ def allow_proxy(func):
 class ListMixin(object):
     @classmethod
     @allow_proxy
-    def all(cls, parent_resource=None, configuration=None, **params):
+    def all(cls, parent_resource=None, configuration=None,
+            user_headers=None, **params):
         response = request(cls._api_session.get,
                            cls.list_path(parent_resource),
-                           configuration=configuration, params=params)
+                           configuration=configuration,
+                           headers=user_headers, params=params)
         data = cls.create_from_data(
             response.json(), parent_resource=parent_resource,
             configuration=configuration)
@@ -213,20 +215,23 @@ class ListMixin(object):
 class RetrieveMixin(object):
     @classmethod
     @allow_proxy
-    def retrieve(cls, id, parent_resource=None, configuration=None, **params):
+    def retrieve(cls, id, parent_resource=None, configuration=None,
+                 user_headers=None, **params):
         instance = cls(id=id, parent_resource=parent_resource,
                        configuration=configuration)
         response = request(cls._api_session.get, instance.detail_path(),
-                           configuration=configuration, params=params)
+                           configuration=configuration,
+                           headers=user_headers, params=params)
         instance.populate(response.json())
         return instance
 
-    def refresh(self):
+    def refresh(self, user_headers=None):
         """
         Retrieves and sets new metadata for the resource.
         """
         response = request(self._api_session.get, self.detail_path(),
-                           configuration=self._configuration)
+                           configuration=self._configuration,
+                           headers=user_headers)
         self.populate(response.json())
 
 
@@ -238,7 +243,7 @@ class CreateMixin(object):
     @classmethod
     @allow_proxy
     def create(cls, data=None, params=None, method='post',
-               parent_resource=None, configuration=None):
+               parent_resource=None, configuration=None, user_headers=None):
         """
         params: A dict containing query parameters.
         data: A dict containing data.
@@ -253,8 +258,8 @@ class CreateMixin(object):
         if not params:
             params = {}
         response = request(method, cls.list_path(parent_resource),
-                           configuration=configuration, data=data,
-                           params=params)
+                           configuration=configuration, headers=user_headers,
+                           data=data, params=params)
         return cls.create_from_data(
             response.json(), parent_resource=parent_resource,
             configuration=configuration)
@@ -267,7 +272,7 @@ class UpdateMixin(object):
         """
         return new_data
 
-    def save(self, **params):
+    def save(self, user_headers=None, **params):
         data = self.serialize(self)
 
         new_data = {}
@@ -288,7 +293,8 @@ class UpdateMixin(object):
                                      "to update.")
             response = request(self._api_session.patch, self.detail_path(),
                                configuration=self._configuration,
-                               data=new_data, params=params)
+                               headers=user_headers, data=new_data,
+                               params=params)
             self.populate(response.json())
 
             # For some resources (eg: File/Folder), the parent resource could
@@ -309,20 +315,22 @@ class UpdateMixin(object):
 
 
 class DeleteMixin(object):
-    def delete(self, **params):
+    def delete(self, user_headers=None, **params):
         request(self._api_session.delete, self.detail_path(),
-                configuration=self._configuration, params=params)
+                configuration=self._configuration,
+                headers=user_headers, params=params)
         self.populate({})
 
 
 class CopyMixin(object):
-    def _copy(self, **data):
+    def _copy(self, user_headers=None, **data):
         """
         Copy the file/folder to another location.
         """
         response = request(self._api_session.post,
                            "%s/copy" % self.detail_path(),
-                           configuration=self._configuration, data=data)
+                           configuration=self._configuration,
+                           headers=user_headers, data=data)
         return self.__class__.create_from_data(
             response.json(), parent_resource=self._parent_resource,
             configuration=self._configuration)
@@ -410,22 +418,22 @@ class Account(BaseResource, ReadMixin, WriteMixin, Proxy):
                 serialized[k] = v
         return serialized
 
-    def convert(self, data=None, params=None):
+    def convert(self, user_headers=None, data=None, params=None):
         params = {} if params is None else params
         data = {} if data is None else data
 
         convert_path = "%s/%s" % (self.detail_path(), 'storage/convert_id')
 
         response = request(self._api_session.post, convert_path,
-                           configuration=self._configuration, data=data,
-                           params=params)
+                           configuration=self._configuration,
+                           headers=user_headers, data=data, params=params)
 
         return response.json()
 
-    def save(self, **params):
+    def save(self, user_headers=None, **params):
         # TODO: add in fields token, token_secret, refresh_token
         request(self._api_session.patch, self.detail_path(),
-                configuration=self._configuration,
+                configuration=self._configuration, headers=user_headers,
                 data=self.serialize_account(self), params=params)
 
     @property
@@ -559,7 +567,7 @@ class File(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
     @classmethod
     @allow_proxy
     def create(cls, file_name='', parent_id='root', file_data='', params=None,
-               parent_resource=None, configuration=None):
+               parent_resource=None, configuration=None, user_headers=None):
         """
         This handles file uploads.
         `file_data` can be either a string with file data in it or a
@@ -572,6 +580,11 @@ class File(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
             }),
             'Content-Type': 'application/octet-stream',
         }
+
+        if user_headers:
+            for k, v in six.iteritems(user_headers):
+                headers[k] = v
+
         response = request(cls._api_session.post, cls.list_path(parent_resource),
                            data=file_data, params=params, headers=headers,
                            configuration=configuration)
@@ -579,7 +592,7 @@ class File(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
             response.json(), parent_resource=parent_resource,
             configuration=configuration)
 
-    def update(self, file_data='', params=None):
+    def update(self, file_data='', params=None, user_headers=None):
         """
         This overwites the file specified by 'file_id' with the contents of
         `file_data`.
@@ -587,13 +600,16 @@ class File(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
         file-like object.
         """
         headers = {'Content-Type': 'application/octet-stream'}
+        if user_headers:
+            for k, v in six.iteritems(user_headers):
+                headers[k] = v
         response = request(self._api_session.put, self.detail_path(),
                            data=file_data, params=params, headers=headers,
                            configuration=self._configuration)
         self.populate(response.json())
         return True
 
-    def contents(self):
+    def contents(self, user_headers=None):
         """
         This handles file downloads. It returns a requests.Response object
         with contents:
@@ -609,20 +625,21 @@ class File(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
         """
         response = request(self._api_session.get,
                            "%s/contents" % self.detail_path(),
-                           configuration=self._configuration, stream=True)
+                           configuration=self._configuration,
+                           headers=user_headers, stream=True)
         return response
 
-    def copy_file(self, **data):
-        return self._copy(**data)
+    def copy_file(self, user_headers=None, **data):
+        return self._copy(user_headers=user_headers, **data)
 
     @classmethod
     @allow_proxy
     def upload_url(cls, data=None, params=None,
-                   parent_resource=None, configuration=None):
+                   parent_resource=None, configuration=None, user_headers=None):
         upload_url_path = "%s/%s" % (cls.list_path(parent_resource), 'upload_url')
         response = request(cls._api_session.post, upload_url_path,
                            configuration=configuration, data=data or {},
-                           params=params or {})
+                           params=params or {}, headers=user_headers)
         return response.json()
 
 
@@ -635,17 +652,18 @@ class Folder(AccountBaseResource, RetrieveMixin, DeleteMixin, UpdateMixin,
         kwargs.setdefault('id', 'root')
         super(Folder, self).__init__(*args, **kwargs)
 
-    def contents(self):
+    def contents(self, user_headers=None):
         response = request(self._api_session.get,
                            "%s/contents" % self.detail_path(),
-                           configuration=self._configuration)
+                           configuration=self._configuration,
+                           headers=user_headers)
         data = self.create_from_data(
             response.json(), parent_resource=self._parent_resource,
             configuration=self._configuration)
         return AnnotatedList(data)
 
-    def copy_folder(self, **data):
-        return self._copy(**data)
+    def copy_folder(self, user_headers=None, **data):
+        return self._copy(user_headers=user_headers, **data)
 
 
 class Link(AccountBaseResource, ReadMixin, WriteMixin):
@@ -665,10 +683,11 @@ class Events(AccountBaseResource, ListMixin):
 
     @classmethod
     @allow_proxy
-    def latest_cursor(cls, parent_resource=None, configuration=None):
+    def latest_cursor(cls, parent_resource=None, configuration=None,
+                      user_headers=None):
         response = request(cls._api_session.get,
                            "%s/latest" % cls.list_path(parent_resource),
-                           configuration=configuration)
+                           configuration=configuration, headers=user_headers)
         data = response.json()
         if 'cursor' in data:
             return data['cursor']
@@ -685,7 +704,8 @@ class Multipart(AccountBaseResource, RetrieveMixin, CreateMixin, DeleteMixin):
     _path_segment = 'storage/multipart'
 
     def upload_chunk(self, part_number=None, data='',
-                     parent_resource=None, configuration=None, **params):
+                     parent_resource=None, configuration=None,
+                     user_headers=None, **params):
         """
         This handles uploading chunks of the file, after a multipart upload has
         been initiated.
@@ -695,18 +715,22 @@ class Multipart(AccountBaseResource, RetrieveMixin, CreateMixin, DeleteMixin):
         """
         params.update({'part_number': part_number})
         headers = {'Content-Type': 'application/octet-stream'}
+        if user_headers:
+            for k, v in six.iteritems(user_headers):
+                headers[k] = v
         request(self._api_session.put, self.detail_path(),
-                data=data, params=params, headers=headers,
+                data=data, params=params, headers=user_headers,
                 configuration=configuration)
         return True
 
-    def complete(self, **params):
+    def complete(self, user_headers=None, **params):
         """
         Completes the multipart upload and returns a File object.
         """
         response = request(self._api_session.post,
                            "%s/complete" % self.detail_path(),
-                           params=params, configuration=self._configuration)
+                           params=params, configuration=self._configuration,
+                           headers=user_headers)
         return File.create_from_data(
             response.json(), parent_resource=self._parent_resource,
             configuration=self._configuration)
@@ -717,10 +741,12 @@ class Permission(FileSystemBaseResource, ListMixin, CreateMixin):
 
     @classmethod
     @allow_proxy
-    def all(cls, parent_resource=None, configuration=None, **params):
+    def all(cls, parent_resource=None, configuration=None,
+            user_headers=None, **params):
         response = request(cls._api_session.get,
                            cls.list_path(parent_resource),
-                           configuration=configuration, params=params)
+                           configuration=configuration, headers=user_headers,
+                           params=params)
 
         response_json = response.json()
         permissions = response_json.get('permissions')
@@ -735,20 +761,22 @@ class Permission(FileSystemBaseResource, ListMixin, CreateMixin):
     @classmethod
     @allow_proxy
     def create(cls, params=None, parent_resource=None, configuration=None,
-               data=None):
+               data=None, user_headers=None):
         return super(Permission, cls).create(params=params,
                                              parent_resource=parent_resource,
                                              configuration=configuration,
-                                             method='put', data=data)
+                                             method='put', data=data,
+                                             user_headers=user_headers)
 
     @classmethod
     @allow_proxy
     def update(cls, params=None, parent_resource=None, configuration=None,
-               data=None):
+               data=None, user_headers=None):
         return super(Permission, cls).create(params=params,
                                              parent_resource=parent_resource,
                                              configuration=configuration,
-                                             method='patch', data=data)
+                                             method='patch', data=data,
+                                             user_headers=user_headers)
 
 
 class Property(FileSystemBaseResource):
@@ -756,47 +784,49 @@ class Property(FileSystemBaseResource):
 
     @classmethod
     @allow_proxy
-    def all(cls, parent_resource=None, configuration=None):
+    def all(cls, parent_resource=None, configuration=None, user_headers=None):
         """
         Returns a full list of custom properties associated with this file.
         """
         response = request(cls._api_session.get,
                            cls.list_path(parent_resource),
-                           configuration=configuration)
+                           configuration=configuration, headers=user_headers)
         return response.json()
 
     @classmethod
     @allow_proxy
-    def update(cls, parent_resource=None, configuration=None, data=None,
-               **params):
+    def update(cls, parent_resource=None, configuration=None, user_headers=None,
+               data=None, **params):
         """
         Updates custom properties associated with this file.
         'data' should be a list of dicts containing key/value pairs.
         """
         response = request(cls._api_session.patch,
                            cls.list_path(parent_resource),
-                           configuration=configuration, data=data,
-                           params=params)
+                           configuration=configuration, headers=user_headers,
+                           data=data, params=params)
         return response.json()
 
     @classmethod
     @allow_proxy
-    def delete_all(cls, parent_resource=None, configuration=None):
+    def delete_all(cls, parent_resource=None, configuration=None,
+                   user_headers=None):
         """
         Deletes all custom properties associated with this file.
         """
         request(cls._api_session.delete, cls.list_path(parent_resource),
-                configuration=configuration)
+                configuration=configuration, headers=user_headers)
         return True
 
 
 class User(AccountBaseResource, ReadMixin):
     _path_segment = 'team/users'
 
-    def get_groups(self, **params):
+    def get_groups(self, user_headers=None, **params):
         response = request(self._api_session.get, "%s/%s" %
                            (self.detail_path(), "memberships"),
-                           configuration=self._configuration, params=params)
+                           configuration=self._configuration,
+                           headers=user_headers, params=params)
 
         data = Group.create_from_data(
             response.json(), parent_resource=self._parent_resource,
@@ -807,10 +837,11 @@ class User(AccountBaseResource, ReadMixin):
 class Group(AccountBaseResource, ReadMixin):
     _path_segment = 'team/groups'
 
-    def get_users(self, **params):
+    def get_users(self, user_headers=None, **params):
         response = request(self._api_session.get, "%s/%s" %
                            (self.detail_path(), "members"),
-                           configuration=self._configuration, params=params)
+                           configuration=self._configuration,
+                           headers=user_headers, params=params)
 
         data = User.create_from_data(
             response.json(), parent_resource=self._parent_resource,
@@ -828,32 +859,37 @@ class CRMObject(AccountBaseResource, ListMixin, CreateMixin, RetrieveMixin,
 
     @classmethod
     @allow_proxy
-    def all(cls, parent_resource=None, configuration=None, **params):
+    def all(cls, parent_resource=None, configuration=None,
+            user_headers=None, **params):
         if cls.raw_type is not None:
             params['raw_type'] = cls.raw_type
         return super(CRMObject, cls).all(parent_resource=parent_resource,
-                                         configuration=configuration, **params)
+                                         configuration=configuration,
+                                         user_headers=user_headers, **params)
 
     @classmethod
     @allow_proxy
     def create(cls, params=None, parent_resource=None, configuration=None,
-               method='post', data=None):
+               user_headers=None, method='post', data=None):
         params = {} if params is None else params
         if cls.raw_type is not None:
             params['raw_type'] = cls.raw_type
         return super(CRMObject, cls).create(params=params,
                                             parent_resource=parent_resource,
                                             configuration=configuration,
+                                            user_headers=user_headers,
                                             method=method, data=data)
 
     @classmethod
     @allow_proxy
-    def retrieve(cls, id, parent_resource=None, configuration=None, **params):
+    def retrieve(cls, id, parent_resource=None, configuration=None,
+                 user_headers=None, **params):
         if cls.raw_type is not None:
             params['raw_type'] = cls.raw_type
         return super(CRMObject, cls).retrieve(id,
                                               parent_resource=parent_resource,
                                               configuration=configuration,
+                                              user_headers=user_headers,
                                               **params)
 
     def save(self, **params):

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -34,6 +34,7 @@ def test_account_retrieve():
         mock_req.assert_called_with(account._api_session.get,
                                     'accounts/%s' % account_data['id'],
                                     configuration=None,
+                                    headers=None,
                                     params={})
 
 @helpers.configured_test
@@ -45,13 +46,14 @@ def test_folder_contents():
         resp.encoding = 'utf-8'
         mock_req.return_value = resp
         folder = account.folders()
-        contents = folder.contents()
+        contents = folder.contents(user_headers={'k': 'v'})
         assert len(contents) > 0
         assert all([(isinstance(x, Folder) or isinstance(x, File)) for x in contents])
         mock_req.assert_called_with(folder._api_session.get,
                                     ('accounts/%s/storage/folders/root/contents'
                                         % account.id),
-                                    configuration=account._configuration)
+                                    configuration=account._configuration,
+                                    headers={'k': 'v'})
 
 @helpers.configured_test
 def test_folder_metadata():
@@ -71,6 +73,7 @@ def test_folder_metadata():
                                     ('accounts/%s/storage/folders/%s'
                                         % (account.id, folder_data['id'])),
                                     configuration=None,
+                                    headers=None,
                                     params={})
 
 @helpers.configured_test
@@ -92,6 +95,7 @@ def test_folder_creation():
         mock_req.assert_called_with(Folder._api_session.post,
                                     'accounts/%s/storage/folders' % account.id,
                                     configuration=None, params={},
+                                    headers=None,
                                     data={'name': 'TestFolder',
                                           'parent_id': 'root'})
 
@@ -110,6 +114,7 @@ def test_folder_delete():
                                     ('accounts/%s/storage/folders/%s'
                                      % (account.id, folder_data['id'])),
                                     configuration=account._configuration,
+                                    headers=None,
                                     params={})
 
 @helpers.configured_test
@@ -130,6 +135,7 @@ def test_file_metadata():
                                     ('accounts/%s/storage/files/%s'
                                         % (account.id, file_data['id'])),
                                     configuration=None,
+                                    headers=None,
                                     params={})
 
 @helpers.configured_test
@@ -147,6 +153,7 @@ def test_file_contents():
                                     ('accounts/%s/storage/files/%s/contents'
                                         % (account.id, file_data['id'])),
                                     configuration=file_obj._configuration,
+                                    headers=None,
                                     stream=True)
 
 @helpers.configured_test
@@ -163,6 +170,7 @@ def test_file_delete():
                                     ('accounts/%s/storage/files/%s'
                                         % (account.id, file_data['id'])),
                                     configuration=file_obj._configuration,
+                                    headers=None,
                                     params={})
 
 @helpers.configured_test
@@ -177,6 +185,7 @@ def test_file_upload():
         file_obj = File.create(parent_resource=account,
                                file_name=file_data['name'],
                                parent_id='root',
+                               user_headers={'k': 'v'},
                                file_data=helpers.file_contents)
         assert isinstance(file_obj, File)
         for attr in ['id', 'name', 'type', 'size', 'account']:
@@ -185,6 +194,7 @@ def test_file_upload():
                                     'accounts/%s/storage/files' % account.id,
                                     data=helpers.file_contents,
                                     headers={
+                                        'k': 'v',
                                         'Content-Type':
                                             'application/octet-stream',
                                         'X-Kloudless-Metadata': json.dumps({
@@ -220,10 +230,12 @@ def test_file_update():
                                params={},
                                data={'name': u'NewFileName',
                                      'parent_id': 'root'},
+                               headers=None,
                                configuration=file_obj._configuration),
                           # This is refreshing the parent resource
                           call(account._api_session.get,
                                'accounts/%s' % account.id,
+                               headers=None,
                                configuration=account._configuration),
                          ]
         mock_req.assert_has_calls(expected_calls)
@@ -250,6 +262,7 @@ def test_file_copy():
                                                          file_data['id']),
                                data={'name': u'NewFileName',
                                      'parent_id': 'root'},
+                               headers=None,
                                configuration=file_obj._configuration),
                          ]
         mock_req.assert_has_calls(expected_calls)


### PR DESCRIPTION
Previously, it was not possible to pass in custom headers for an API
function. This is required for some features such as impersonating a
user with `X-Kloudless-As-User`.

Example:
```
account.files.retrieve(id='Fpb5D71ihUffoegT2Sg1PVp1AENF0zwgWATlz7vj0gYlXPHnR1ZM1jenclmP7Ivhh', user_headers={'X-Kloudless-As-User': 'uY2Jhcm5lc0BzbWFydGZpbGUuY29t'})
```